### PR TITLE
Add SAC 2026 payment link

### DIFF
--- a/src/content/blog/en/sac-2026/payments.md
+++ b/src/content/blog/en/sac-2026/payments.md
@@ -32,7 +32,7 @@ The fee will vary according to the following dates:
 
 If you are Colombian or have bank accounts in Colombia, you may make the payment using the following methods:
 
-For the registration to be approved, payment must be made through the [**following link**](), and your registration will be approved once it has been verified by the organizing team.
+For the registration to be approved, payment must be made through the [**following link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed), and your registration will be approved once it has been verified by the organizing team.
 
 **BANCO DAVIVIENDA** via bank transfer to the following account:
 

--- a/src/content/blog/pt/sac-2026/pagamentos.md
+++ b/src/content/blog/pt/sac-2026/pagamentos.md
@@ -32,7 +32,7 @@ O custo variará de acordo com as seguintes datas:
 
 Se você é colombiano ou possui contas bancárias na Colômbia, poderá realizar o pagamento das seguintes formas:
 
-Para que o registro seja aprovado, é necessário realizar o pagamento no [**link seguinte**](), e seu registro será aprovado após verificação pela equipe organizadora.
+Para que o registro seja aprovado, é necessário realizar o pagamento no [**link seguinte**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed), e seu registro será aprovado após verificação pela equipe organizadora.
 
 **BANCO DAVIVIENDA** por meio de transferência bancária para a seguinte conta:
 

--- a/src/content/blog/sac-2026/pagos.md
+++ b/src/content/blog/sac-2026/pagos.md
@@ -32,7 +32,7 @@ El costo variará de acuerdo a las siguientes fechas:
 
 Si eres colombiano o tienes cuentas bancarias en Colombia podrás realizar el pago de las siguientes maneras:
 
-Para que el registro quede aprobado se debe realizar el pago al [**siguiente link**]() y tu registro será aprobado una vez sea verificado por el  equipo organizador.
+Para que el registro quede aprobado se debe realizar el pago al [**siguiente link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed) y tu registro será aprobado una vez sea verificado por el  equipo organizador.
 
 **BANCO DAVIVIENDA** mediante transferencia bancaria a la siguiente cuenta:
 


### PR DESCRIPTION
This pull request updates the payment instructions for SAC 2026 registration in three different language blog posts. The primary change is that the placeholder payment link has been replaced with the actual payment URL, ensuring users can now access the correct payment page.

**Payment instructions update:**

* Replaced the placeholder payment link with the actual URL (`https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed`) in the English (`src/content/blog/en/sac-2026/payments.md`), Portuguese (`src/content/blog/pt/sac-2026/pagamentos.md`), and Spanish (`src/content/blog/sac-2026/pagos.md`) payment instruction sections. [[1]](diffhunk://#diff-289b697a7f3c3acce48a4fb70cfe1a1890ea3a97ef4ce2216c3b691f81902eb4L35-R35) [[2]](diffhunk://#diff-c6402592228f5ad3233f4606a7b12941ff70b46b08d96ab0468031df8991c1e1L35-R35) [[3]](diffhunk://#diff-54a6dfbc5ab0131e782d761bd21981f07094241ebfafacdad5d546bf88e95b5fL35-R35)