### PR TITLE
Fix SAC 2026 payment instructions

### DIFF
--- a/src/content/blog/en/sac-2026/payments.md
+++ b/src/content/blog/en/sac-2026/payments.md
@@ -32,8 +32,6 @@ The fee will vary according to the following dates:
 
 If you are Colombian or have bank accounts in Colombia, you may make the payment using the following methods:
 
-For the registration to be approved, payment must be made through the [**following link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed), and your registration will be approved once it has been verified by the organizing team.
-
 **BANCO DAVIVIENDA** via bank transfer to the following account:
 
 - **Bank:** Davivienda  
@@ -48,6 +46,11 @@ For the registration to be approved, payment must be made through the [**followi
 You can scan the QR code to pay using the Bre-B key:
 
 ![QR llave bre-b](/sac/pagosbrebqr.jpg)
+
+If you are a competitor from outside Colombia, you may complete the payment using the Epayco payment link:
+
+For your registration to be approved, you must complete the payment through the [**following link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed), and your registration will be approved once it has been verified by the organizing team.
+
 ---
 
 ### 🟢 STEP 3 — SEND THE CONFIRMATION EMAIL

--- a/src/content/blog/pt/sac-2026/pagamentos.md
+++ b/src/content/blog/pt/sac-2026/pagamentos.md
@@ -32,8 +32,6 @@ O custo variará de acordo com as seguintes datas:
 
 Se você é colombiano ou possui contas bancárias na Colômbia, poderá realizar o pagamento das seguintes formas:
 
-Para que o registro seja aprovado, é necessário realizar o pagamento no [**link seguinte**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed), e seu registro será aprovado após verificação pela equipe organizadora.
-
 **BANCO DAVIVIENDA** por meio de transferência bancária para a seguinte conta:
 
 - **Banco:** Davivienda  
@@ -48,6 +46,11 @@ Para que o registro seja aprovado, é necessário realizar o pagamento no [**lin
 Você pode escanear o QR para pagar com a chave Bre-B:
 
 ![QR llave bre-b](/sac/pagosbrebqr.jpg)
+
+Se você é um competidor de fora da Colômbia, poderá realizar o pagamento por meio do link de pagamento Epayco:
+
+Para que o registro seja aprovado, é necessário realizar o pagamento pelo [**seguinte link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed) e seu registro será aprovado assim que for verificado pela equipe organizadora.
+
 ---
 
 ### 🟢 PASSO 3 — ENVIE O E-MAIL DE CONFIRMAÇÃO

--- a/src/content/blog/sac-2026/pagos.md
+++ b/src/content/blog/sac-2026/pagos.md
@@ -50,6 +50,7 @@ Puedes escanear el QR para pagar con llave Bre-b:
 Si eres un competidor de afuera de Colombia podrás realizar el pago mediante el link de pago Epayco:
 
 Para que el registro quede aprobado se debe realizar el pago al [**siguiente link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed) y tu registro será aprobado una vez sea verificado por el  equipo organizador.
+
 ---
 
 ### 🟢 PASO 3 — ENVÍA EL CORREO DE CONFIRMACIÓN

--- a/src/content/blog/sac-2026/pagos.md
+++ b/src/content/blog/sac-2026/pagos.md
@@ -32,8 +32,6 @@ El costo variará de acuerdo a las siguientes fechas:
 
 Si eres colombiano o tienes cuentas bancarias en Colombia podrás realizar el pago de las siguientes maneras:
 
-Para que el registro quede aprobado se debe realizar el pago al [**siguiente link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed) y tu registro será aprobado una vez sea verificado por el  equipo organizador.
-
 **BANCO DAVIVIENDA** mediante transferencia bancaria a la siguiente cuenta:
 
 - **Banco:** Davivienda  
@@ -48,6 +46,10 @@ Para que el registro quede aprobado se debe realizar el pago al [**siguiente lin
 Puedes escanear el QR para pagar con llave Bre-b:
 
 ![QR llave bre-b](/sac/pagosbrebqr.jpg)
+
+Si eres un competidor de afuera de Colombia podrás realizar el pago mediante el link de pago Epayco:
+
+Para que el registro quede aprobado se debe realizar el pago al [**siguiente link**](https://payco.link/92f54fec-afc1-417b-9da6-e09192ee69ed) y tu registro será aprobado una vez sea verificado por el  equipo organizador.
 ---
 
 ### 🟢 PASO 3 — ENVÍA EL CORREO DE CONFIRMACIÓN


### PR DESCRIPTION
This pull request updates the payment instructions for SAC 2026 registration in English, Portuguese, and Spanish blog posts. The main improvement is clarifying and adding instructions for international competitors to pay via the Epayco payment link, ensuring the process is clear for both local and international participants.

**Payment instructions update:**

* Added a new section in the English (`payments.md`), Portuguese (`pagamentos.md`), and Spanish (`pagos.md`) blog posts with instructions for international competitors to pay using the Epayco payment link, including a clarification that registration will be approved after payment verification. [[1]](diffhunk://#diff-289b697a7f3c3acce48a4fb70cfe1a1890ea3a97ef4ce2216c3b691f81902eb4R49-R53) [[2]](diffhunk://#diff-c6402592228f5ad3233f4606a7b12941ff70b46b08d96ab0468031df8991c1e1R49-R53) [[3]](diffhunk://#diff-54a6dfbc5ab0131e782d761bd21981f07094241ebfafacdad5d546bf88e95b5fR49-R53)
* Removed the previous generic payment link instruction for local competitors from all three language files to avoid confusion, making the local and international payment instructions more distinct. [[1]](diffhunk://#diff-289b697a7f3c3acce48a4fb70cfe1a1890ea3a97ef4ce2216c3b691f81902eb4L35-L36) [[2]](diffhunk://#diff-c6402592228f5ad3233f4606a7b12941ff70b46b08d96ab0468031df8991c1e1L35-L36) [[3]](diffhunk://#diff-54a6dfbc5ab0131e782d761bd21981f07094241ebfafacdad5d546bf88e95b5fL35-L36)